### PR TITLE
Decompress value during warmup load data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "dashmap",
+ "memcached_codec",
  "parking_lot",
  "rand",
  "serde",

--- a/ep_engine/Cargo.toml
+++ b/ep_engine/Cargo.toml
@@ -14,3 +14,4 @@ rand = "0.8.5"
 byteorder = "1.5.0"
 bitflags = "2.4.1"
 crc32fast = "1.3.2"
+memcached_codec = { path = "../memcached_codec" }

--- a/ep_engine/src/hash_table.rs
+++ b/ep_engine/src/hash_table.rs
@@ -32,6 +32,7 @@ impl HashTable {
             flags: item.flags,
             rev_seqno: item.rev_seqno,
             bits: Default::default(),
+            data_type: item.data_type,
         };
         self.map.entry(item.key).or_insert(value)
     }

--- a/ep_engine/src/item.rs
+++ b/ep_engine/src/item.rs
@@ -1,3 +1,5 @@
+use memcached_codec::DataType;
+
 pub struct Item {
     pub key: Vec<u8>,
     pub value: Option<Vec<u8>>,
@@ -6,4 +8,5 @@ pub struct Item {
     pub flags: u32,
     pub by_seqno: u64,
     pub rev_seqno: u64,
+    pub data_type: DataType,
 }

--- a/ep_engine/src/kv_store.rs
+++ b/ep_engine/src/kv_store.rs
@@ -1,5 +1,6 @@
 use crate::vbucket::{VBucketState, Vbid};
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
+use memcached_codec::DataType;
 use parking_lot::RwLock;
 use std::{
     cmp::Ordering,
@@ -284,6 +285,8 @@ pub struct Metadata {
     pub cas: u64,
     pub expiry_time: u32,
     pub flags: u32,
+    pub flex_code: u8,
+    pub data_type: DataType,
 }
 
 impl Metadata {
@@ -291,10 +294,14 @@ impl Metadata {
         let cas = r.read_u64::<BigEndian>().unwrap();
         let expiry_time = r.read_u32::<BigEndian>().unwrap();
         let flags = r.read_u32::<LittleEndian>().unwrap();
+        let flex_code = r.read_u8().unwrap();
+        let data_type = DataType::try_from(r.read_u8().unwrap()).unwrap();
         Metadata {
             cas,
             expiry_time,
             flags,
+            flex_code,
+            data_type,
         }
     }
 }

--- a/ep_engine/src/stored_value.rs
+++ b/ep_engine/src/stored_value.rs
@@ -1,5 +1,6 @@
 use crate::item::Item;
 use bitflags::bitflags;
+use memcached_codec::DataType;
 
 /// Value that is stored in the hash table
 #[derive(Debug, Clone)]
@@ -13,6 +14,7 @@ pub struct StoredValue {
     pub flags: u32,
     pub rev_seqno: u64,
     pub(crate) bits: StoredValueBits,
+    pub data_type: DataType,
 }
 
 bitflags! {
@@ -50,6 +52,7 @@ impl StoredValue {
         self.expiry_time = item.expiry_time;
         self.flags = item.flags;
         self.rev_seqno = item.rev_seqno;
+        self.data_type = item.data_type;
 
         self.mark_resident();
     }


### PR DESCRIPTION
Missed the fact that kv_engine overrides the data type during warmup